### PR TITLE
fix: css applied globally if scoping fails

### DIFF
--- a/src/sparkle-instance.vue
+++ b/src/sparkle-instance.vue
@@ -44,7 +44,7 @@ export default {
   z-index: 2;
   animation: growAndShrink 600ms ease-in-out forwards;
 }
-svg{
+.sparkleWrapper>svg{
   animation: spin 600ms linear forwards;
 }
 


### PR DESCRIPTION
In our rather complicated Vue setup scoping is not a failsafe way to stop css from having unwanted side effects, thus it is needed to further refine the css selectors.